### PR TITLE
Make suitable to be used in development 

### DIFF
--- a/express-webpack-assets.js
+++ b/express-webpack-assets.js
@@ -19,7 +19,7 @@ module.exports = function(manifestPath) {
 
     function getAsset(path) {
 
-        if(!isManifestLoaded) {
+        if(process.env.NODE_ENV === 'dev' || !isManifestLoaded) {
             manifest = loadManifest();
         }
 


### PR DESCRIPTION
With this change, express-webpack-asset can be used in development as config will be reloaded on every request provided `NODE_ENV` requals `dev`.
