### PR TITLE
Adding posibility to pass a directory as manifest path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ app.use(webpackAssets('./config/webpack-assets.json', {
 }));
 ```
 
+Express-webpack-asset can also support you with multiple json files. For that case you need to pass a path of your assets json files, example of usage:
+```javascript
+var webpackAssets = require('express-webpack-assets');
+app.use(webpackAssets('./config', {
+	devMode: true/false
+}));
+```
+Please bear in mind that result of extend will override the object properties with equal names w.r.t. order returned by Nodejs.fs.readDir.
+
 ## Options
 
 ```javascript

--- a/express-webpack-assets.js
+++ b/express-webpack-assets.js
@@ -1,4 +1,15 @@
 var fs = require('fs')
+var path = require('path')
+
+function extend(target) {
+  var sources = [].slice.call(arguments, 1);
+  sources.forEach(function (source) {
+    for (var prop in source) {
+      target[prop] = source[prop];
+    }
+  });
+  return target;
+}
 
 module.exports = function (manifestPath, options) {
   var manifest
@@ -10,7 +21,20 @@ module.exports = function (manifestPath, options) {
 
   function loadManifest () {
     try {
-      var data = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+      var data = {};
+
+      if (fs.statSync(manifestPath).isDirectory()) {
+        var manifestFiles = fs.readdirSync(manifestPath);
+        if (manifestFiles.length === 0) {
+          console.error('there are no asset manifest', e)
+        }
+        manifestFiles.forEach(function (manifest) {
+          extend(data, JSON.parse(fs.readFileSync(path.resolve(manifestPath, manifest), 'utf8')));
+        });
+      } else {
+        data = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+      }
+
       isManifestLoaded = true
       return data
     } catch(e) {


### PR DESCRIPTION
I have a case when I need stats from multiple webpack runs.
